### PR TITLE
Fix: Update all deprecated nbviewer links to nbviewer.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 | 1     | Exploratory data analysis                                    | [**Notebook**](http://nbviewer.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Skin_Cancer_EDA.ipynb) |
 | 2     | Baseline model                                               | [**Notebook**](http://nbviewer.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Baseline_CNN.ipynb) |
 | 3     | Fine-tuning the last convolutional block of VGG16            | [**Notebook**](http://nbviewer.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Fine_Tuning_VGG16.ipynb) |
-| 4     | Fine-tuning the top 2 inception blocks of InceptionV3        | [**Notebook**](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_InceptionV3.ipynb) |
-| 5     | Fine-tuning the Inception-ResNet-C of Inception-ResNet V2    | [**Notebook**](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_InceptionResNet.ipynb) |
-| 6     | Fine-tuning the last dense block of DenseNet 201             | **[Notebook](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_DenseNet.ipynb)** |
-| 7     | Fine-tuning all layers of pretrained Inception V3 on ImageNet | [**Notebook**](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Retraining_InceptionV3.ipynb) |
-| 8     | Fine-tuning all layers of pretrained DenseNet 201 on ImageNet | [**Notebook**](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Retraining_DenseNet.ipynb) |
-| 9     | Ensemble model of the fully fine-tuned Inception V3 and DenseNet 201 | **[Notebook](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Ensemble_Models.ipynb)** |
+| 4     | Fine-tuning the top 2 inception blocks of InceptionV3        | [**Notebook**](https://nbviewer.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_InceptionV3.ipynb) |
+| 5     | Fine-tuning the Inception-ResNet-C of Inception-ResNet V2    | [**Notebook**](https://nbviewer.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_InceptionResNet.ipynb) |
+| 6     | Fine-tuning the last dense block of DenseNet 201             | **[Notebook](https://nbviewer.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_DenseNet.ipynb)** |
+| 7     | Fine-tuning all layers of pretrained Inception V3 on ImageNet | [**Notebook**](https://nbviewer.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Retraining_InceptionV3.ipynb) |
+| 8     | Fine-tuning all layers of pretrained DenseNet 201 on ImageNet | [**Notebook**](https://nbviewer.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Retraining_DenseNet.ipynb) |
+| 9     | Ensemble model of the fully fine-tuned Inception V3 and DenseNet 201 | **[Notebook](https://nbviewer.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Ensemble_Models.ipynb)** |
 
 
 ## Technical Issue

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 | Sr.No | File Name                                                    | Link                                                         |
 | ----- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| 1     | Exploratory data analysis                                    | [**Notebook**](http://nbviewer.ipython.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Skin_Cancer_EDA.ipynb) |
-| 2     | Baseline model                                               | [**Notebook**](http://nbviewer.ipython.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Baseline_CNN.ipynb) |
-| 3     | Fine-tuning the last convolutional block of VGG16            | [**Notebook**](http://nbviewer.ipython.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Fine_Tuning_VGG16.ipynb) |
+| 1     | Exploratory data analysis                                    | [**Notebook**](http://nbviewer.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Skin_Cancer_EDA.ipynb) |
+| 2     | Baseline model                                               | [**Notebook**](http://nbviewer.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Baseline_CNN.ipynb) |
+| 3     | Fine-tuning the last convolutional block of VGG16            | [**Notebook**](http://nbviewer.org/urls/raw.github.com/ashishpatel26/Skin-Lesions-Detection-Deep-learning/main/Notebooks/Fine_Tuning_VGG16.ipynb) |
 | 4     | Fine-tuning the top 2 inception blocks of InceptionV3        | [**Notebook**](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_InceptionV3.ipynb) |
 | 5     | Fine-tuning the Inception-ResNet-C of Inception-ResNet V2    | [**Notebook**](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_InceptionResNet.ipynb) |
 | 6     | Fine-tuning the last dense block of DenseNet 201             | **[Notebook](https://nbviewer.jupyter.org/github/ashishpatel26/Skin-Lesions-Detection-Deep-learning/blob/main/Notebooks/Fine_Tuning_DenseNet.ipynb)** |


### PR DESCRIPTION
## What this PR does

The notebook viewer links in README.md were using two deprecated domains:
- `nbviewer.ipython.org` (deprecated)
- `nbviewer.jupyter.org` (deprecated)

Both of these now redirect or fail. This PR updates all 9 notebook links to use the current official domain: `nbviewer.org`

## Changes
- Updated 3 links from `nbviewer.ipython.org` → `nbviewer.org`
- Updated 6 links from `nbviewer.jupyter.org` → `nbviewer.org`

All notebook links in the Files Tables section are now functional.